### PR TITLE
Integrate Firestore workouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+android-commandlinetools.zip

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-database-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-storage-ktx")
 
     // Coroutines support for Task APIs
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1")

--- a/app/src/main/java/com/fernando/fitlife/FitLifeApp.kt
+++ b/app/src/main/java/com/fernando/fitlife/FitLifeApp.kt
@@ -15,6 +15,7 @@ import com.fernando.fitlife.viewmodel.FavoritosPersonalViewModel
 import com.fernando.fitlife.viewmodel.SettingsViewModel
 import com.fernando.fitlife.viewmodel.AuthViewModel
 import com.fernando.fitlife.viewmodel.TrainerViewModel
+import com.fernando.fitlife.viewmodel.WorkoutsViewModel
 
 @Composable
 fun FitLifeApp(
@@ -22,7 +23,8 @@ fun FitLifeApp(
     favoritosPersonalViewModel: FavoritosPersonalViewModel,
     settingsViewModel: SettingsViewModel,
     authViewModel: AuthViewModel,
-    trainerViewModel: TrainerViewModel
+    trainerViewModel: TrainerViewModel,
+    workoutsViewModel: WorkoutsViewModel
 ) {
     val navController = rememberNavController()
     val isDarkTheme by settingsViewModel.darkMode.collectAsState()
@@ -38,7 +40,8 @@ fun FitLifeApp(
                 favoritosPersonalViewModel = favoritosPersonalViewModel,
                 settingsViewModel = settingsViewModel,
                 authViewModel = authViewModel,
-                trainerViewModel = trainerViewModel
+                trainerViewModel = trainerViewModel,
+                workoutsViewModel = workoutsViewModel
             )
         }
     }

--- a/app/src/main/java/com/fernando/fitlife/MainActivity.kt
+++ b/app/src/main/java/com/fernando/fitlife/MainActivity.kt
@@ -19,6 +19,7 @@ import com.fernando.fitlife.viewmodel.FavoritosPersonalViewModel
 import com.fernando.fitlife.viewmodel.SettingsViewModel
 import com.fernando.fitlife.viewmodel.AuthViewModel
 import com.fernando.fitlife.viewmodel.TrainerViewModel
+import com.fernando.fitlife.viewmodel.WorkoutsViewModel
 import com.fernando.fitlife.worker.SyncWorker
 import java.util.concurrent.TimeUnit
 
@@ -29,6 +30,7 @@ class MainActivity : ComponentActivity() {
     private val settingsViewModel: SettingsViewModel by viewModels()
     private val authViewModel: AuthViewModel by viewModels()
     private val trainerViewModel: TrainerViewModel by viewModels()
+    private val workoutsViewModel: WorkoutsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,7 +43,8 @@ class MainActivity : ComponentActivity() {
                 favoritosPersonalViewModel = favoritosPersonalViewModel,
                 settingsViewModel = settingsViewModel,
                 authViewModel = authViewModel,
-                trainerViewModel = trainerViewModel
+                trainerViewModel = trainerViewModel,
+                workoutsViewModel = workoutsViewModel
             )
         }
     }

--- a/app/src/main/java/com/fernando/fitlife/data/model/TreinosMock.kt
+++ b/app/src/main/java/com/fernando/fitlife/data/model/TreinosMock.kt
@@ -1,38 +1,37 @@
 package com.fernando.fitlife.data.model
 
-import com.fernando.fitlife.R
 import com.fernando.fitlife.model.Treino
 
 val treinosMock = listOf(
     Treino(
-        id = 1,
+        id = "1",
         nome = "Treino Cardio",
         descricao = "Queime calorias e melhore seu condicionamento.",
-        imagemUrl = R.drawable.treino1,
+        imagemUrl = "",
         duracaoMin = 30,
         nivel = "Iniciante"
     ),
     Treino(
-        id = 2,
+        id = "2",
         nome = "Musculação Avançada",
         descricao = "Foco em hipertrofia e ganho de massa.",
-        imagemUrl = R.drawable.treino2,
+        imagemUrl = "",
         duracaoMin = 60,
         nivel = "Avançado"
     ),
     Treino(
-        id = 3,
+        id = "3",
         nome = "Yoga Relaxante",
         descricao = "Sessão para aliviar o estresse e melhorar a flexibilidade.",
-        imagemUrl = R.drawable.treino3,
+        imagemUrl = "",
         duracaoMin = 45,
         nivel = "Intermediário"
     ),
     Treino(
-        id = 4,
+        id = "4",
         nome = "HIIT Explosivo",
         descricao = "Treino intenso em intervalos para queima rápida de gordura.",
-        imagemUrl = R.drawable.treino4,
+        imagemUrl = "",
         duracaoMin = 20,
         nivel = "Avançado"
     )

--- a/app/src/main/java/com/fernando/fitlife/data/model/personaisMock.kt
+++ b/app/src/main/java/com/fernando/fitlife/data/model/personaisMock.kt
@@ -9,20 +9,20 @@ val personaisMock = listOf(
         nome = "homer simpson",
         especialidade = "Hipertrofia",
         descricao = "Treinador com foco em musculação e ganho de massa.",
-        imagemUrl = R.drawable.personal1
+        imagemUrl = ""
     ),
     Personal(
         id = 2,
         nome = "johnny bravo",
         especialidade = "Emagrecimento",
         descricao = "Ajuda você a perder peso de forma saudável.",
-         imagemUrl = R.drawable.personal2
+         imagemUrl = ""
     ),
     Personal(
         id = 3,
         nome = "pai do chris",
         especialidade = "Corrida",
         descricao = "Especialista em performance e resistência.",
-         imagemUrl = R.drawable.personal3
-    )
+         imagemUrl = ""
+)
 )

--- a/app/src/main/java/com/fernando/fitlife/database/FitLifeDatabase.kt
+++ b/app/src/main/java/com/fernando/fitlife/database/FitLifeDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.fernando.fitlife.model.Treino
 
-@Database(entities = [Treino::class], version = 1, exportSchema = false)
+@Database(entities = [Treino::class], version = 2, exportSchema = false)
 abstract class FitLifeDatabase : RoomDatabase() {
 
     abstract fun treinoDao(): TreinoDao

--- a/app/src/main/java/com/fernando/fitlife/database/TreinoDao.kt
+++ b/app/src/main/java/com/fernando/fitlife/database/TreinoDao.kt
@@ -10,12 +10,15 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TreinoDao {
-    @Query("SELECT * FROM treinos")
-    fun getFavoritos(): Flow<List<Treino>>
+    @Query("SELECT * FROM treinos WHERE userId = :userId")
+    fun getFavoritos(userId: String): Flow<List<Treino>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun adicionar(treino: Treino)
 
     @Delete
     suspend fun remover(treino: Treino)
+
+    @Query("DELETE FROM treinos WHERE userId = :userId")
+    suspend fun clear(userId: String)
 }

--- a/app/src/main/java/com/fernando/fitlife/model/Client.kt
+++ b/app/src/main/java/com/fernando/fitlife/model/Client.kt
@@ -1,0 +1,6 @@
+package com.fernando.fitlife.model
+
+data class Client(
+    val id: String = "",
+    val nome: String = ""
+)

--- a/app/src/main/java/com/fernando/fitlife/model/Personal.kt
+++ b/app/src/main/java/com/fernando/fitlife/model/Personal.kt
@@ -1,9 +1,9 @@
 package com.fernando.fitlife.model
 
 data class Personal(
-    val id: Int,
-    val nome: String,
-    val especialidade: String,
-    val descricao: String,
-     val imagemUrl: Int
+    val id: Int = 0,
+    val nome: String = "",
+    val especialidade: String = "",
+    val descricao: String = "",
+    val imagemUrl: String = ""
 )

--- a/app/src/main/java/com/fernando/fitlife/model/TrainerWorkout.kt
+++ b/app/src/main/java/com/fernando/fitlife/model/TrainerWorkout.kt
@@ -1,0 +1,7 @@
+package com.fernando.fitlife.model
+
+data class TrainerWorkout(
+    val id: String,
+    val treino: Treino,
+    val clientName: String
+)

--- a/app/src/main/java/com/fernando/fitlife/model/Treino.kt
+++ b/app/src/main/java/com/fernando/fitlife/model/Treino.kt
@@ -6,13 +6,11 @@ import androidx.room.PrimaryKey
 // Adicione a anotação @Entity aqui
 @Entity(tableName = "treinos")
 data class Treino(
-    // Adicione a anotação @PrimaryKey aqui
     @PrimaryKey
-    val id: Int,
-
-    val nome: String,
-    val descricao: String,
-    val imagemUrl: Int,
-    val duracaoMin: Int,
-    val nivel: String
+    val id: Int = 0,
+    val nome: String = "",
+    val descricao: String = "",
+    val imagemUrl: Int = 0,
+    val duracaoMin: Int = 0,
+    val nivel: String = ""
 )

--- a/app/src/main/java/com/fernando/fitlife/model/Treino.kt
+++ b/app/src/main/java/com/fernando/fitlife/model/Treino.kt
@@ -3,14 +3,16 @@ package com.fernando.fitlife.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-// Adicione a anotação @Entity aqui
 @Entity(tableName = "treinos")
 data class Treino(
     @PrimaryKey
-    val id: Int = 0,
+    val id: String = "",
     val nome: String = "",
     val descricao: String = "",
-    val imagemUrl: Int = 0,
+    val imagemUrl: String = "",
     val duracaoMin: Int = 0,
-    val nivel: String = ""
+    val nivel: String = "",
+    val trainerId: String = "",
+    val clientId: String = "",
+    val userId: String = ""
 )

--- a/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
+++ b/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
@@ -12,6 +12,7 @@ import com.fernando.fitlife.viewmodel.FavoritosPersonalViewModel
 import com.fernando.fitlife.viewmodel.SettingsViewModel
 import com.fernando.fitlife.viewmodel.AuthViewModel
 import com.fernando.fitlife.viewmodel.TrainerViewModel
+import com.fernando.fitlife.viewmodel.WorkoutsViewModel
 
 @Composable
 fun FitLifeNavGraph(
@@ -20,7 +21,8 @@ fun FitLifeNavGraph(
     favoritosPersonalViewModel: FavoritosPersonalViewModel,
     settingsViewModel: SettingsViewModel,
     authViewModel: AuthViewModel,
-    trainerViewModel: TrainerViewModel
+    trainerViewModel: TrainerViewModel,
+    workoutsViewModel: WorkoutsViewModel
 ) {
     val startDestination = if (authViewModel.currentUser == null) "login" else "home"
     NavHost(navController = navController, startDestination = startDestination) {
@@ -41,7 +43,8 @@ fun FitLifeNavGraph(
             HomeScreen(
                 navController = navController,
                 favoritosViewModel = favoritosViewModel,
-                authViewModel = authViewModel
+                authViewModel = authViewModel,
+                workoutsViewModel = workoutsViewModel
             )
         }
 
@@ -50,7 +53,8 @@ fun FitLifeNavGraph(
             DetalhesScreen(
                 treinoId = treinoId,
                 navController = navController,
-                favoritosViewModel = favoritosViewModel
+                favoritosViewModel = favoritosViewModel,
+                workoutsViewModel = workoutsViewModel
             )
         }
 
@@ -73,7 +77,8 @@ fun FitLifeNavGraph(
         composable("personais") {
             PersonaisScreen(
                 navController = navController,
-                favoritosViewModel = favoritosPersonalViewModel
+                favoritosViewModel = favoritosPersonalViewModel,
+                trainerViewModel = trainerViewModel
             )
         }
 

--- a/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
+++ b/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
@@ -48,7 +48,8 @@ fun FitLifeNavGraph(
                 navController = navController,
                 favoritosViewModel = favoritosViewModel,
                 authViewModel = authViewModel,
-                workoutsViewModel = workoutsViewModel
+                workoutsViewModel = workoutsViewModel,
+                trainerViewModel = trainerViewModel
             )
         }
 

--- a/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
+++ b/app/src/main/java/com/fernando/fitlife/navigation/FitLifeNavGraph.kt
@@ -36,7 +36,11 @@ fun FitLifeNavGraph(
         }
 
         composable("trainer") {
-            TrainerMenuScreen(navController = navController, trainerViewModel = trainerViewModel)
+            TrainerMenuScreen(
+                navController = navController,
+                trainerViewModel = trainerViewModel,
+                authViewModel = authViewModel
+            )
         }
 
         composable("home") {
@@ -49,7 +53,7 @@ fun FitLifeNavGraph(
         }
 
         composable("detalhes/{treinoId}") { backStackEntry ->
-            val treinoId = backStackEntry.arguments?.getString("treinoId")?.toIntOrNull() ?: 0
+            val treinoId = backStackEntry.arguments?.getString("treinoId") ?: ""
             DetalhesScreen(
                 treinoId = treinoId,
                 navController = navController,

--- a/app/src/main/java/com/fernando/fitlife/repository/AuthRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/AuthRepository.kt
@@ -20,11 +20,26 @@ class AuthRepository {
         }
     }
 
-    suspend fun register(email: String, password: String, role: String): Boolean {
+    suspend fun register(
+        email: String,
+        password: String,
+        role: String,
+        nome: String,
+        especialidade: String? = null,
+        descricao: String? = null,
+        fotoUrl: String? = null
+    ): Boolean {
         return try {
             auth.createUserWithEmailAndPassword(email, password).await()
             val uid = auth.currentUser!!.uid
-            firestore.collection("users").document(uid).set(mapOf("role" to role)).await()
+            val data = mutableMapOf<String, Any>(
+                "role" to role,
+                "nome" to nome
+            )
+            especialidade?.let { data["especialidade"] = it }
+            descricao?.let { data["descricao"] = it }
+            fotoUrl?.let { data["fotoUrl"] = it }
+            firestore.collection("users").document(uid).set(data).await()
             true
         } catch (e: Exception) {
             false

--- a/app/src/main/java/com/fernando/fitlife/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/FavoritesRepository.kt
@@ -1,0 +1,24 @@
+package com.fernando.fitlife.repository
+
+import android.content.Context
+import com.fernando.fitlife.database.FitLifeDatabase
+import com.fernando.fitlife.model.Treino
+import kotlinx.coroutines.flow.Flow
+
+class FavoritesRepository(context: Context) {
+    private val dao = FitLifeDatabase.getDatabase(context).treinoDao()
+
+    fun getFavorites(userId: String): Flow<List<Treino>> = dao.getFavoritos(userId)
+
+    suspend fun addFavorite(treino: Treino, userId: String) {
+        dao.adicionar(treino.copy(userId = userId))
+    }
+
+    suspend fun removeFavorite(treino: Treino) {
+        dao.remover(treino)
+    }
+
+    suspend fun clear(userId: String) {
+        dao.clear(userId)
+    }
+}

--- a/app/src/main/java/com/fernando/fitlife/repository/FirebaseRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/FirebaseRepository.kt
@@ -8,10 +8,7 @@ class FirebaseRepository {
     private val auth = FirebaseAuth.getInstance()
     private val database = FirebaseDatabase.getInstance().getReference("users")
 
-    fun syncFavoritos(favoritos: List<Treino>) {
-        val userId = auth.currentUser?.uid
-        if (userId != null) {
-            database.child(userId).child("favoritos").setValue(favoritos)
-        }
+    fun syncFavoritos(userId: String, favoritos: List<Treino>) {
+        database.child(userId).child("favoritos").setValue(favoritos)
     }
 }

--- a/app/src/main/java/com/fernando/fitlife/repository/TrainerRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/TrainerRepository.kt
@@ -1,5 +1,6 @@
 package com.fernando.fitlife.repository
 
+import com.fernando.fitlife.model.Personal
 import com.fernando.fitlife.model.Treino
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -13,6 +14,22 @@ class TrainerRepository {
             .get()
             .await()
         return snapshot.documents.map { it.id }
+    }
+
+    suspend fun getTrainers(): List<Personal> {
+        val snapshot = firestore.collection("users")
+            .whereEqualTo("role", "trainer")
+            .get()
+            .await()
+        return snapshot.documents.map { doc ->
+            Personal(
+                id = 0,
+                nome = doc.getString("nome") ?: "",
+                especialidade = doc.getString("especialidade") ?: "",
+                descricao = doc.getString("descricao") ?: "",
+                imagemUrl = doc.getLong("imagemUrl")?.toInt() ?: 0
+            )
+        }
     }
 
     suspend fun addWorkout(clientId: String, treino: Treino) {

--- a/app/src/main/java/com/fernando/fitlife/repository/TrainerRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/TrainerRepository.kt
@@ -95,15 +95,19 @@ class TrainerRepository {
     }
 
     suspend fun uploadWorkoutImage(clientId: String, workoutId: String, uri: Uri): String {
-        val ref = storage.reference.child("workouts/$workoutId.jpg")
-        ref.putFile(uri).await()
-        val url = ref.downloadUrl.await().toString()
-        firestore.collection("users")
-            .document(clientId)
-            .collection("treinos")
-            .document(workoutId)
-            .update("imagemUrl", url)
-            .await()
-        return url
+        return try {
+            val ref = storage.reference.child("workouts/$workoutId.jpg")
+            ref.putFile(uri).await()
+            val url = ref.downloadUrl.await().toString()
+            firestore.collection("users")
+                .document(clientId)
+                .collection("treinos")
+                .document(workoutId)
+                .update("imagemUrl", url)
+                .await()
+            url
+        } catch (e: Exception) {
+            ""
+        }
     }
 }

--- a/app/src/main/java/com/fernando/fitlife/repository/WorkoutRepository.kt
+++ b/app/src/main/java/com/fernando/fitlife/repository/WorkoutRepository.kt
@@ -1,0 +1,18 @@
+package com.fernando.fitlife.repository
+
+import com.fernando.fitlife.model.Treino
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class WorkoutRepository {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    suspend fun getWorkoutsForUser(userId: String): List<Treino> {
+        val snapshot = firestore.collection("users")
+            .document(userId)
+            .collection("treinos")
+            .get()
+            .await()
+        return snapshot.toObjects(Treino::class.java)
+    }
+}

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/DetalhesScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/DetalhesScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
-import com.fernando.fitlife.data.model.treinosMock
 import com.fernando.fitlife.viewmodel.FavoritosViewModel
+import com.fernando.fitlife.viewmodel.WorkoutsViewModel
 import com.fernando.fitlife.ui.components.BotaoFavorito
 import com.fernando.fitlife.ui.components.DetalheItem
 
@@ -21,9 +21,10 @@ import com.fernando.fitlife.ui.components.DetalheItem
 fun DetalhesScreen(
     treinoId: Int,
     navController: NavController,
-    favoritosViewModel: FavoritosViewModel = viewModel()
+    favoritosViewModel: FavoritosViewModel = viewModel(),
+    workoutsViewModel: WorkoutsViewModel = viewModel()
 ) {
-    val treino = treinosMock.find { it.id == treinoId } ?: return
+    val treino = workoutsViewModel.workouts.find { it.id == treinoId } ?: return
     var mostrarDescricao by remember { mutableStateOf(true) }
 
     val isFavorito by remember { derivedStateOf { favoritosViewModel.isFavorito(treino) } }

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/DetalhesScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/DetalhesScreen.kt
@@ -19,7 +19,7 @@ import com.fernando.fitlife.ui.components.DetalheItem
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetalhesScreen(
-    treinoId: Int,
+    treinoId: String,
     navController: NavController,
     favoritosViewModel: FavoritosViewModel = viewModel(),
     workoutsViewModel: WorkoutsViewModel = viewModel()

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
@@ -17,20 +17,21 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import coil.compose.AsyncImage
-import com.fernando.fitlife.data.model.treinosMock
 import com.fernando.fitlife.model.Treino
 import com.fernando.fitlife.ui.components.BottomBar
 import com.fernando.fitlife.ui.components.BotaoFavorito
 import com.fernando.fitlife.ui.components.DetalheItem
 import com.fernando.fitlife.viewmodel.FavoritosViewModel
 import com.fernando.fitlife.viewmodel.AuthViewModel
+import com.fernando.fitlife.viewmodel.WorkoutsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     navController: NavController,
     favoritosViewModel: FavoritosViewModel = viewModel(),
-    authViewModel: AuthViewModel = viewModel()
+    authViewModel: AuthViewModel = viewModel(),
+    workoutsViewModel: WorkoutsViewModel = viewModel()
 ) {
     var expanded by remember { mutableStateOf(false) }
     val navBackStackEntry = navController.currentBackStackEntryAsState()
@@ -41,11 +42,12 @@ fun HomeScreen(
     LaunchedEffect(Unit) {
         if (authViewModel.currentUser != null) {
             authViewModel.loadRole()
+            workoutsViewModel.loadWorkouts(authViewModel.currentUser!!.uid)
         }
     }
 
     var busca by remember { mutableStateOf("") }
-    val treinosFiltrados = treinosMock.filter {
+    val treinosFiltrados = workoutsViewModel.workouts.filter {
         it.nome.contains(busca, ignoreCase = true)
     }
 

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Add
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -31,9 +35,17 @@ fun HomeScreen(
     navController: NavController,
     favoritosViewModel: FavoritosViewModel = viewModel(),
     authViewModel: AuthViewModel = viewModel(),
-    workoutsViewModel: WorkoutsViewModel = viewModel()
+    workoutsViewModel: WorkoutsViewModel = viewModel(),
+    trainerViewModel: com.fernando.fitlife.viewmodel.TrainerViewModel = viewModel()
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var uploadTarget by remember { mutableStateOf<Pair<String, String>?>(null) }
+    val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        val target = uploadTarget
+        if (uri != null && target != null) {
+            trainerViewModel.uploadImage(target.first, target.second, uri, authViewModel.currentUser!!.uid)
+        }
+    }
     val navBackStackEntry = navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry.value?.destination?.route ?: "home"
 
@@ -43,12 +55,16 @@ fun HomeScreen(
         if (authViewModel.currentUser != null) {
             authViewModel.loadRole()
             workoutsViewModel.loadWorkouts(authViewModel.currentUser!!.uid)
+            trainerViewModel.loadTrainerWorkouts(authViewModel.currentUser!!.uid)
             favoritosViewModel.setUser(authViewModel.currentUser!!.uid)
         }
     }
 
     var busca by remember { mutableStateOf("") }
-    val treinosFiltrados = workoutsViewModel.workouts.filter {
+    val trainerTreinos = trainerViewModel.trainerWorkouts.filter {
+        it.treino.nome.contains(busca, ignoreCase = true)
+    }
+    val clientTreinos = workoutsViewModel.workouts.filter {
         it.nome.contains(busca, ignoreCase = true)
     }
 
@@ -78,15 +94,6 @@ fun HomeScreen(
                                 navController.navigate("configuracoes")
                             }
                         )
-                        if (role == "trainer") {
-                            DropdownMenuItem(
-                                text = { Text("Treinador") },
-                                onClick = {
-                                    expanded = false
-                                    navController.navigate("trainer")
-                                }
-                            )
-                        }
                         DropdownMenuItem(
                             text = { Text("Ajuda") },
                             onClick = {
@@ -111,6 +118,13 @@ fun HomeScreen(
         },
         bottomBar = {
             BottomBar(navController = navController, currentRoute = currentRoute)
+        },
+        floatingActionButton = {
+            if (role == "trainer") {
+                FloatingActionButton(onClick = { navController.navigate("trainer") }) {
+                    Icon(Icons.Default.Add, contentDescription = "Criar treino")
+                }
+            }
         }
     ) { padding ->
         Column(modifier = Modifier.padding(padding)) {
@@ -124,21 +138,39 @@ fun HomeScreen(
             )
 
             LazyColumn {
-                items(treinosFiltrados) { treino ->
-                    TreinoCard(
-                        treino = treino,
-                        isFavorito = favoritosViewModel.isFavorito(treino),
-                        onToggleFavorito = {
-                            if (favoritosViewModel.isFavorito(treino)) {
-                                favoritosViewModel.remover(treino)
-                            } else {
-                                favoritosViewModel.adicionar(treino)
+                if (role == "trainer") {
+                    items(trainerTreinos) { item ->
+                        TrainerWorkoutCard(
+                            workout = item,
+                            onUploadPhoto = {
+                                uploadTarget = item.treino.clientId to item.id
+                                imageLauncher.launch("image/*")
+                            },
+                            onDelete = {
+                                trainerViewModel.deleteWorkout(item.treino.clientId, item.id, authViewModel.currentUser!!.uid)
+                            },
+                            onClick = {
+                                navController.navigate("detalhes/${item.treino.id}")
                             }
-                        },
-                        onClick = {
-                            navController.navigate("detalhes/${treino.id}")
-                        }
-                    )
+                        )
+                    }
+                } else {
+                    items(clientTreinos) { treino ->
+                        TreinoCard(
+                            treino = treino,
+                            isFavorito = favoritosViewModel.isFavorito(treino),
+                            onToggleFavorito = {
+                                if (favoritosViewModel.isFavorito(treino)) {
+                                    favoritosViewModel.remover(treino)
+                                } else {
+                                    favoritosViewModel.adicionar(treino)
+                                }
+                            },
+                            onClick = {
+                                navController.navigate("detalhes/${treino.id}")
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -190,6 +222,46 @@ fun TreinoCard(
                     text = treino.descricao ?: "Sem descrição.",
                     modifier = Modifier.padding(top = 8.dp)
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun TrainerWorkoutCard(
+    workout: com.fernando.fitlife.model.TrainerWorkout,
+    onUploadPhoto: () -> Unit,
+    onDelete: () -> Unit,
+    onClick: () -> Unit
+) {
+    val treino = workout.treino
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable { onClick() }
+    ) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                AsyncImage(
+                    model = treino.imagemUrl,
+                    contentDescription = treino.nome,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.size(100.dp)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(treino.nome, fontWeight = FontWeight.Bold)
+                    Text("Aluno: ${workout.clientName}")
+                    Text("${treino.duracaoMin} min • ${treino.nivel}")
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onUploadPhoto) { Text("Foto") }
+                TextButton(onClick = onDelete) { Text("Excluir") }
             }
         }
     }

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/HomeScreen.kt
@@ -43,6 +43,7 @@ fun HomeScreen(
         if (authViewModel.currentUser != null) {
             authViewModel.loadRole()
             workoutsViewModel.loadWorkouts(authViewModel.currentUser!!.uid)
+            favoritosViewModel.setUser(authViewModel.currentUser!!.uid)
         }
     }
 
@@ -97,6 +98,7 @@ fun HomeScreen(
                             text = { Text("Sair") },
                             onClick = {
                                 expanded = false
+                                favoritosViewModel.clearInMemory()
                                 authViewModel.logout()
                                 navController.navigate("login") {
                                     popUpTo("home") { inclusive = true }

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/PersonaisScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/PersonaisScreen.kt
@@ -15,19 +15,24 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
-import com.fernando.fitlife.data.model.personaisMock
 import com.fernando.fitlife.model.Personal
 import com.fernando.fitlife.viewmodel.FavoritosPersonalViewModel
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.LocalContentColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PersonaisScreen(
     navController: NavController,
-    favoritosViewModel: FavoritosPersonalViewModel
+    favoritosViewModel: FavoritosPersonalViewModel,
+    trainerViewModel: com.fernando.fitlife.viewmodel.TrainerViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
 ) {
     val favoritos by favoritosViewModel.favoritos.collectAsState()
+    val trainers = trainerViewModel.trainers
+
+    LaunchedEffect(Unit) {
+        trainerViewModel.loadTrainers()
+    }
 
     Scaffold(
         topBar = {
@@ -55,7 +60,7 @@ fun PersonaisScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            items(personaisMock) { personal ->
+            items(trainers) { personal ->
                 PersonalCard(
                     personal = personal,
                     favoritosViewModel = favoritosViewModel

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.fernando.fitlife.model.Treino
+import com.fernando.fitlife.model.TrainerWorkout
 import com.fernando.fitlife.viewmodel.AuthViewModel
 import com.fernando.fitlife.viewmodel.TrainerViewModel
 
@@ -97,16 +98,16 @@ fun TrainerMenuScreen(
         if (trainerViewModel.trainerWorkouts.isNotEmpty()) {
             Text("Seus treinos:")
             LazyColumn(modifier = Modifier.height(200.dp)) {
-                items(trainerViewModel.trainerWorkouts) { pair ->
-                    val workoutId = pair.first
-                    val treino = pair.second
+                items(trainerViewModel.trainerWorkouts) { item ->
+                    val workoutId = item.id
+                    val treino = item.treino
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Column {
                             Text(treino.nome)
-                            Text("Aluno: ${treino.clientId}")
+                            Text("Aluno: ${item.clientName}")
                         }
                         Row {
                             TextButton(onClick = {

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
@@ -1,5 +1,8 @@
 package com.fernando.fitlife.ui.screens
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,21 +13,31 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.fernando.fitlife.model.Treino
+import com.fernando.fitlife.viewmodel.AuthViewModel
 import com.fernando.fitlife.viewmodel.TrainerViewModel
 
 @Composable
 fun TrainerMenuScreen(
     navController: NavController,
-    trainerViewModel: TrainerViewModel = viewModel()
+    trainerViewModel: TrainerViewModel = viewModel(),
+    authViewModel: AuthViewModel = viewModel()
 ) {
     var nome by remember { mutableStateOf("") }
     var descricao by remember { mutableStateOf("") }
     var duracao by remember { mutableStateOf("") }
     var nivel by remember { mutableStateOf("") }
     var selectedClient by remember { mutableStateOf<com.fernando.fitlife.model.Client?>(null) }
+    var uploadTarget by remember { mutableStateOf<Pair<String, String>?>(null) }
+    val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        val target = uploadTarget
+        if (uri != null && target != null) {
+            trainerViewModel.uploadImage(target.first, target.second, uri, authViewModel.currentUser!!.uid)
+        }
+    }
 
     LaunchedEffect(Unit) {
         trainerViewModel.loadClients()
+        authViewModel.currentUser?.uid?.let { trainerViewModel.loadTrainerWorkouts(it) }
     }
 
     LaunchedEffect(selectedClient) {
@@ -60,11 +73,13 @@ fun TrainerMenuScreen(
                 val client = selectedClient
                 if (client != null) {
                     val treino = Treino(
-                        id = (System.currentTimeMillis() % Int.MAX_VALUE).toInt(),
+                        id = "${System.currentTimeMillis()}",
                         nome = nome,
                         descricao = descricao,
                         duracaoMin = duracao.toIntOrNull() ?: 0,
-                        nivel = nivel
+                        nivel = nivel,
+                        trainerId = authViewModel.currentUser!!.uid,
+                        clientId = client.id
                     )
                     trainerViewModel.addWorkout(client.id, treino)
                     nome = ""
@@ -77,6 +92,33 @@ fun TrainerMenuScreen(
             enabled = selectedClient != null && nome.isNotBlank() && duracao.isNotBlank()
         ) {
             Text("Criar treino")
+        }
+
+        if (trainerViewModel.trainerWorkouts.isNotEmpty()) {
+            Text("Seus treinos:")
+            LazyColumn(modifier = Modifier.height(200.dp)) {
+                items(trainerViewModel.trainerWorkouts) { pair ->
+                    val workoutId = pair.first
+                    val treino = pair.second
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text(treino.nome)
+                            Text("Aluno: ${treino.clientId}")
+                        }
+                        Row {
+                            TextButton(onClick = {
+                                uploadTarget = treino.clientId to workoutId
+                                imageLauncher.launch("image/*")
+                            }) { Text("Foto") }
+                            TextButton(onClick = { trainerViewModel.deleteWorkout(treino.clientId, workoutId, authViewModel.currentUser!!.uid) }) { Text("Excluir") }
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
@@ -54,11 +54,11 @@ fun TrainerMenuScreen(
             }
         }
 
+        val context = LocalContext.current
         Button(
             onClick = {
                 val client = selectedClient
                 if (client != null) {
-                    val context = androidx.compose.ui.platform.LocalContext.current
                     val imageId = context.resources.getIdentifier(imagem, "drawable", context.packageName)
                     val treino = Treino(
                         id = 0,

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/TrainerMenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -19,6 +20,9 @@ fun TrainerMenuScreen(
 ) {
     var nome by remember { mutableStateOf("") }
     var descricao by remember { mutableStateOf("") }
+    var imagem by remember { mutableStateOf("") }
+    var duracao by remember { mutableStateOf("") }
+    var nivel by remember { mutableStateOf("") }
     var selectedClient by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
@@ -33,6 +37,9 @@ fun TrainerMenuScreen(
     ) {
         OutlinedTextField(value = nome, onValueChange = { nome = it }, label = { Text("Nome do treino") })
         OutlinedTextField(value = descricao, onValueChange = { descricao = it }, label = { Text("Descrição") })
+        OutlinedTextField(value = imagem, onValueChange = { imagem = it }, label = { Text("Imagem (nome do recurso)") })
+        OutlinedTextField(value = duracao, onValueChange = { duracao = it }, label = { Text("Duração em minutos") })
+        OutlinedTextField(value = nivel, onValueChange = { nivel = it }, label = { Text("Nível") })
 
         Text("Selecione o cliente:")
         LazyColumn(modifier = Modifier.height(150.dp)) {
@@ -51,14 +58,26 @@ fun TrainerMenuScreen(
             onClick = {
                 val client = selectedClient
                 if (client != null) {
-                    val treino = Treino(0, nome, descricao, 0, 30, "")
+                    val context = androidx.compose.ui.platform.LocalContext.current
+                    val imageId = context.resources.getIdentifier(imagem, "drawable", context.packageName)
+                    val treino = Treino(
+                        id = 0,
+                        nome = nome,
+                        descricao = descricao,
+                        imagemUrl = imageId,
+                        duracaoMin = duracao.toIntOrNull() ?: 0,
+                        nivel = nivel
+                    )
                     trainerViewModel.addWorkout(client, treino)
                     nome = ""
                     descricao = ""
+                    imagem = ""
+                    duracao = ""
+                    nivel = ""
                     selectedClient = null
                 }
             },
-            enabled = selectedClient != null && nome.isNotBlank()
+            enabled = selectedClient != null && nome.isNotBlank() && duracao.isNotBlank()
         ) {
             Text("Criar treino")
         }

--- a/app/src/main/java/com/fernando/fitlife/ui/screens/auth/RegisterScreen.kt
+++ b/app/src/main/java/com/fernando/fitlife/ui/screens/auth/RegisterScreen.kt
@@ -17,7 +17,11 @@ fun RegisterScreen(
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var nome by remember { mutableStateOf("") }
     var trainer by remember { mutableStateOf(false) }
+    var especialidade by remember { mutableStateOf("") }
+    var descricao by remember { mutableStateOf("") }
+    var fotoUrl by remember { mutableStateOf("") }
     val role by authViewModel.role.collectAsState()
 
     LaunchedEffect(role) {
@@ -35,11 +39,27 @@ fun RegisterScreen(
     ) {
         OutlinedTextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
         OutlinedTextField(value = password, onValueChange = { password = it }, label = { Text("Senha") })
+        OutlinedTextField(value = nome, onValueChange = { nome = it }, label = { Text("Nome") })
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = trainer, onCheckedChange = { trainer = it })
             Text("Registrar como treinador")
         }
-        Button(onClick = { authViewModel.register(email, password, trainer) }) {
+        if (trainer) {
+            OutlinedTextField(value = especialidade, onValueChange = { especialidade = it }, label = { Text("Especialidade") })
+            OutlinedTextField(value = descricao, onValueChange = { descricao = it }, label = { Text("Descrição") })
+            OutlinedTextField(value = fotoUrl, onValueChange = { fotoUrl = it }, label = { Text("URL da foto (opcional)") })
+        }
+        Button(onClick = {
+            authViewModel.register(
+                email,
+                password,
+                trainer,
+                nome,
+                especialidade.takeIf { trainer },
+                descricao.takeIf { trainer },
+                fotoUrl.takeIf { trainer && fotoUrl.isNotBlank() }
+            )
+        }) {
             Text("Registrar")
         }
     }

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/AuthViewModel.kt
@@ -20,9 +20,25 @@ class AuthViewModel : ViewModel() {
         }
     }
 
-    fun register(email: String, password: String, trainer: Boolean) {
+    fun register(
+        email: String,
+        password: String,
+        trainer: Boolean,
+        nome: String,
+        especialidade: String? = null,
+        descricao: String? = null,
+        fotoUrl: String? = null
+    ) {
         viewModelScope.launch {
-            val success = repo.register(email, password, if (trainer) "trainer" else "client")
+            val success = repo.register(
+                email,
+                password,
+                if (trainer) "trainer" else "client",
+                nome,
+                especialidade,
+                descricao,
+                fotoUrl
+            )
             if (success) {
                 _role.value = if (trainer) "trainer" else "client"
             }

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/FavoritosViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/FavoritosViewModel.kt
@@ -1,15 +1,22 @@
 package com.fernando.fitlife.viewmodel
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.fernando.fitlife.model.Treino
+import com.fernando.fitlife.repository.FavoritesRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import androidx.compose.runtime.mutableStateListOf
 
-class FavoritosViewModel : ViewModel() {
+class FavoritosViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repo = FavoritesRepository(application)
+
+    private var currentUserId: String? = null
 
     // Lista observável de treinos favoritos
     private val _favoritos = mutableStateListOf<Treino>()
@@ -19,16 +26,28 @@ class FavoritosViewModel : ViewModel() {
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
+    fun setUser(userId: String) {
+        if (currentUserId == userId) return
+        currentUserId = userId
+        viewModelScope.launch {
+            repo.getFavorites(userId).collectLatest { list ->
+                _favoritos.clear()
+                _favoritos.addAll(list)
+            }
+        }
+    }
+
     // Adiciona um treino à lista de favoritos
     fun adicionar(treino: Treino) {
+        val uid = currentUserId ?: return
         if (treino !in _favoritos) {
-            _favoritos.add(treino)
+            viewModelScope.launch { repo.addFavorite(treino, uid) }
         }
     }
 
     // Remove um treino da lista de favoritos
     fun remover(treino: Treino) {
-        _favoritos.remove(treino)
+        viewModelScope.launch { repo.removeFavorite(treino) }
     }
 
     // Verifica se um treino está na lista de favoritos
@@ -41,8 +60,16 @@ class FavoritosViewModel : ViewModel() {
         viewModelScope.launch {
             _isLoading.value = true
             delay(1000) // Simulação de processo async
+            val uid = currentUserId
+            if (uid != null) {
+                repo.clear(uid)
+            }
             _favoritos.clear()
             _isLoading.value = false
         }
+    }
+
+    fun clearInMemory() {
+        _favoritos.clear()
     }
 }

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
@@ -1,5 +1,6 @@
 package com.fernando.fitlife.viewmodel
 
+import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -23,6 +24,9 @@ class TrainerViewModel : ViewModel() {
     var clientWorkouts by mutableStateOf<List<Treino>>(emptyList())
         private set
 
+    var trainerWorkouts by mutableStateOf<List<Pair<String, Treino>>>(emptyList())
+        private set
+
     fun loadClients() {
         viewModelScope.launch {
             clients = repo.getClients()
@@ -39,6 +43,7 @@ class TrainerViewModel : ViewModel() {
         viewModelScope.launch {
             repo.addWorkout(clientId, treino)
             loadWorkouts(clientId)
+            loadTrainerWorkouts(treino.trainerId)
         }
     }
 
@@ -48,4 +53,23 @@ class TrainerViewModel : ViewModel() {
         }
     }
 
+    fun loadTrainerWorkouts(trainerId: String) {
+        viewModelScope.launch {
+            trainerWorkouts = repo.getWorkoutsForTrainer(trainerId)
+        }
+    }
+
+    fun deleteWorkout(clientId: String, workoutId: String, trainerId: String) {
+        viewModelScope.launch {
+            repo.deleteWorkout(clientId, workoutId)
+            loadTrainerWorkouts(trainerId)
+        }
+    }
+
+    fun uploadImage(clientId: String, workoutId: String, uri: Uri, trainerId: String) {
+        viewModelScope.launch {
+            repo.uploadWorkoutImage(clientId, workoutId, uri)
+            loadTrainerWorkouts(trainerId)
+        }
+    }
 }

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fernando.fitlife.model.Personal
 import com.fernando.fitlife.model.Treino
 import com.fernando.fitlife.repository.TrainerRepository
 import kotlinx.coroutines.launch
@@ -13,6 +14,9 @@ class TrainerViewModel : ViewModel() {
     private val repo = TrainerRepository()
 
     var clients by mutableStateOf<List<String>>(emptyList())
+        private set
+
+    var trainers by mutableStateOf<List<Personal>>(emptyList())
         private set
 
     fun loadClients() {
@@ -26,4 +30,11 @@ class TrainerViewModel : ViewModel() {
             repo.addWorkout(clientId, treino)
         }
     }
+
+    fun loadTrainers() {
+        viewModelScope.launch {
+            trainers = repo.getTrainers()
+        }
+    }
+
 }

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.fernando.fitlife.model.Client
 import com.fernando.fitlife.model.Personal
 import com.fernando.fitlife.model.Treino
+import com.fernando.fitlife.model.TrainerWorkout
 import com.fernando.fitlife.repository.TrainerRepository
 import kotlinx.coroutines.launch
 
@@ -24,7 +25,7 @@ class TrainerViewModel : ViewModel() {
     var clientWorkouts by mutableStateOf<List<Treino>>(emptyList())
         private set
 
-    var trainerWorkouts by mutableStateOf<List<Pair<String, Treino>>>(emptyList())
+    var trainerWorkouts by mutableStateOf<List<TrainerWorkout>>(emptyList())
         private set
 
     fun loadClients() {

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/TrainerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fernando.fitlife.model.Client
 import com.fernando.fitlife.model.Personal
 import com.fernando.fitlife.model.Treino
 import com.fernando.fitlife.repository.TrainerRepository
@@ -13,10 +14,13 @@ import kotlinx.coroutines.launch
 class TrainerViewModel : ViewModel() {
     private val repo = TrainerRepository()
 
-    var clients by mutableStateOf<List<String>>(emptyList())
+    var clients by mutableStateOf<List<Client>>(emptyList())
         private set
 
     var trainers by mutableStateOf<List<Personal>>(emptyList())
+        private set
+
+    var clientWorkouts by mutableStateOf<List<Treino>>(emptyList())
         private set
 
     fun loadClients() {
@@ -25,9 +29,16 @@ class TrainerViewModel : ViewModel() {
         }
     }
 
+    fun loadWorkouts(clientId: String) {
+        viewModelScope.launch {
+            clientWorkouts = repo.getWorkoutsForClient(clientId)
+        }
+    }
+
     fun addWorkout(clientId: String, treino: Treino) {
         viewModelScope.launch {
             repo.addWorkout(clientId, treino)
+            loadWorkouts(clientId)
         }
     }
 

--- a/app/src/main/java/com/fernando/fitlife/viewmodel/WorkoutsViewModel.kt
+++ b/app/src/main/java/com/fernando/fitlife/viewmodel/WorkoutsViewModel.kt
@@ -1,0 +1,23 @@
+package com.fernando.fitlife.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fernando.fitlife.model.Treino
+import com.fernando.fitlife.repository.WorkoutRepository
+import kotlinx.coroutines.launch
+
+class WorkoutsViewModel : ViewModel() {
+    private val repo = WorkoutRepository()
+
+    var workouts by mutableStateOf<List<Treino>>(emptyList())
+        private set
+
+    fun loadWorkouts(userId: String) {
+        viewModelScope.launch {
+            workouts = repo.getWorkoutsForUser(userId)
+        }
+    }
+}

--- a/app/src/main/java/com/fernando/fitlife/worker/SyncWorker.kt
+++ b/app/src/main/java/com/fernando/fitlife/worker/SyncWorker.kt
@@ -16,8 +16,10 @@ class SyncWorker(
         val database = FitLifeDatabase.getDatabase(applicationContext)
         val firebaseRepository = FirebaseRepository()
 
-        val favoritos = database.treinoDao().getFavoritos().first()
-        firebaseRepository.syncFavoritos(favoritos)
+        val userId = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+            ?: return Result.success()
+        val favoritos = database.treinoDao().getFavoritos(userId).first()
+        firebaseRepository.syncFavoritos(userId, favoritos)
 
         return Result.success()
     }


### PR DESCRIPTION
## Summary
- load client workouts from Firestore using a new repository and viewmodel
- show only trainers from Firestore
- allow trainers to specify image, duration and level when adding workouts
- wire new WorkoutsViewModel through MainActivity, FitLifeApp and navigation

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_6885149ff6048329a9e7c6e152931a8f